### PR TITLE
Hide answers with missing translations

### DIFF
--- a/config.json
+++ b/config.json
@@ -116,6 +116,14 @@
 			"default": ""
 		},
 		{
+			"key": "hide-answers-without-translation",
+			"name": "Hide Answers that do not have a translation. (Radio/Dropdown/Checkbox Options without a translation for the current language will not be displayed)",
+			"required": false,
+			"type": "checkbox",
+			"repeatable": false,
+			"default": ""
+		},
+		{
 			"key": "multilingual-econsent",
 			"name": "Use multilingual PDFs for eConsent/survey download",
 			"required": false,

--- a/config.json
+++ b/config.json
@@ -124,8 +124,24 @@
 			"default": ""
 		},
 		{
+			"key": "hide-matrix-questions-without-translation",
+			"name": "Hide Matrix Field Questions that do not have a translation on instruments. (Matrix Rows/Questions without a translation for the current language will not be displayed)",
+			"required": false,
+			"type": "checkbox",
+			"repeatable": false,
+			"default": ""
+		},
+		{
 			"key": "hide-answers-without-translation-survey",
 			"name": "Hide Answers that do not have a translation on surveys. (Radio/Dropdown/Checkbox Options without a translation for the current language will not be displayed)",
+			"required": false,
+			"type": "checkbox",
+			"repeatable": false,
+			"default": ""
+		},
+		{
+			"key": "hide-matrix-questions-without-translation-survey",
+			"name": "Hide Matrix Field Questions that do not have a translation on surveys. (Matrix Rows/Questions without a translation for the current language will not be displayed)",
 			"required": false,
 			"type": "checkbox",
 			"repeatable": false,

--- a/config.json
+++ b/config.json
@@ -117,7 +117,15 @@
 		},
 		{
 			"key": "hide-answers-without-translation",
-			"name": "Hide Answers that do not have a translation. (Radio/Dropdown/Checkbox Options without a translation for the current language will not be displayed)",
+			"name": "Hide Answers that do not have a translation on instruments. (Radio/Dropdown/Checkbox Options without a translation for the current language will not be displayed)",
+			"required": false,
+			"type": "checkbox",
+			"repeatable": false,
+			"default": ""
+		},
+		{
+			"key": "hide-answers-without-translation-survey",
+			"name": "Hide Answers that do not have a translation on surveys. (Radio/Dropdown/Checkbox Options without a translation for the current language will not be displayed)",
 			"required": false,
 			"type": "checkbox",
 			"repeatable": false,

--- a/js/multilingual.js
+++ b/js/multilingual.js
@@ -149,11 +149,12 @@
 					var id2;
 					for(id2 in translations['answers'][id]['text']){
 						$('[name="' + id + '"] option').each(function(){
+							$(this).show();
 							if($(this).val() == id2){
 								$(this).text(translations['answers'][id]['text'][id2]);
-								console.log('Translation found for '+id+' option '+id2);
-							} else {
-								console.log('No Translation for '+id+' option '+id2);
+								$(this).data('lang', lang);
+							} else if(settings['hide-answers-without-translation']['value'] && $(this).val() !== '' && $(this).data('lang') !== lang) {
+								$(this).hide();
 							}
 						});
 					}
@@ -180,9 +181,14 @@
 					var id2;
 					for(id2 in translations['answers'][id]['text']){
 						$('[name="' + id + '___radio"]').each(function(){
+							$(this).parent().contents().last().show();
+							$(this).show();
 							if($(this).val() == id2){
-								//$(this).parent().contents().last().replaceWith(' ' + translations['answers'][id]['text'][id2]);
 								$(this).parent().contents().last().html(' ' + translations['answers'][id]['text'][id2]);
+								$(this).data('lang', lang);
+							} else if(settings['hide-answers-without-translation']['value'] && $(this).data('lang') !== lang) {
+								$(this).parent().contents().last().hide();
+								$(this).hide();
 							}
 						});
 					}
@@ -190,9 +196,14 @@
 				else if(translations['answers'][id]['type'] == 'checkbox'){
 					var id2;
 					for(id2 in translations['answers'][id]['text']){
-						$('[name="__chk__' + id + '_RC_' + id2 + '"]').each(function(){
-							//$(this).parent().contents().last().replaceWith(' ' + translations['answers'][id]['text'][id2]);
-							$(this).parent().contents().last().html(' ' + translations['answers'][id]['text'][id2]);
+						$('#'+id+'-tr .choicevert').each(function(){
+							$(this).show();
+							if($(this).find('[name="__chk__' + id + '_RC_' + id2 + '"]').length) {
+								$(this).contents().last().html(' ' + translations['answers'][id]['text'][id2]);
+								$(this).data('lang', lang);
+							} else if(settings['hide-answers-without-translation']['value'] && $(this).data('lang') !== lang) {
+								$(this).hide();
+							}
 						});
 					}
 				}

--- a/js/multilingual.js
+++ b/js/multilingual.js
@@ -151,6 +151,9 @@
 						$('[name="' + id + '"] option').each(function(){
 							if($(this).val() == id2){
 								$(this).text(translations['answers'][id]['text'][id2]);
+								console.log('Translation found for '+id+' option '+id2);
+							} else {
+								console.log('No Translation for '+id+' option '+id2);
 							}
 						});
 					}

--- a/js/multilingual.js
+++ b/js/multilingual.js
@@ -17,6 +17,7 @@
 	var translations = {};
 	var errorChecking = 0;
 	var anyTranslated = false;
+	var matrixProcessed = {};
 
 	//document ready change language
 	$( document ).ready(function(){
@@ -130,6 +131,18 @@
 			var id;
 			for(id in translations['questions']){
 				if(translations['questions'][id]['matrix'] != null){
+					if(!(translations['questions'][id]['matrix'] in matrixProcessed) && settings['hide-matrix-questions-without-translation']['value']) {
+						$('tr[mtxgrp="'+translations['questions'][id]['matrix']+'"].mtxfld').each(function(){
+							var curMtxQuestionId = $(this).attr('id');
+							curMtxQuestionId = curMtxQuestionId.replace('-tr', '');
+							if(typeof translations['questions'][curMtxQuestionId] == 'undefined') {
+								$(this).hide();
+							} else {
+								$(this).show();
+							}
+						});
+						matrixProcessed[translations['questions'][id]['matrix']] = true;
+					}
 					$('#' + id + '-tr').children().children().children().children().children().children().children().children().children().children('td:first').html(translations['questions'][id]['text']);
 				}
 				else if(translations['questions'][id]['type'] == 'descriptive'){
@@ -299,6 +312,7 @@
 					translations = r;
 					langReady = 1;
 					anyTranslated = true;
+					matrixProcessed = {};
 				}
 			},
 			error: function(jqXHR, textStatus, errorThrown) {

--- a/js/multilingual_survey.js
+++ b/js/multilingual_survey.js
@@ -552,8 +552,12 @@
 					var id2;
 					for(id2 in translations['answers'][id]['text']){
 						$('[name="' + id + '"] option').each(function(){
+							$(this).show();
 							if($(this).val() == id2){
 								$(this).text(translations['answers'][id]['text'][id2]);
+								$(this).data('lang', lang);
+							} else if($(this).val() !== '' && $(this).data('lang') !== lang) {
+								$(this).hide();
 							}
 						});
 					}
@@ -588,9 +592,14 @@
 					var id2;
 					for(id2 in translations['answers'][id]['text']){
 						$('[name="' + id + '___radio"]').each(function(){
+							$(this).parent().contents().last().show();
+							$(this).show();
 							if($(this).val() == id2){
-								//$(this).parent().contents().last().replaceWith(' ' + translations['answers'][id]['text'][id2]);
 								$(this).parent().contents().last().html(' ' + translations['answers'][id]['text'][id2]);
+								$(this).data('lang', lang);
+							} else if($(this).data('lang') !== lang) {
+								$(this).parent().contents().last().hide();
+								$(this).hide();
 							}
 						});
 					}
@@ -598,8 +607,12 @@
 					for(id2 in translations['answers'][id]['text']){
 						$('.ec').each(function(){
 							var tmp = $(this).parent().attr('comps').split(',');
-							if(tmp[0] == id && tmp[2] == id2){
-								$(this).html(translations['answers'][id]['text'][id2]);
+							$(this).show();
+							if(tmp[0] == id && tmp[2] == id2) {
+								$(this).html(' ' + translations['answers'][id]['text'][id2]);
+								$(this).data('lang', lang);
+							} else if($(this).data('lang') !== lang) {
+								$(this).hide();
 							}
 						});
 					}
@@ -607,17 +620,26 @@
 				else if(translations['answers'][id]['type'] == 'checkbox'){
 					var id2;
 					for(id2 in translations['answers'][id]['text']){
-						$('[name="__chk__' + id + '_RC_' + id2 + '"]').each(function(){
-							//$(this).parent().contents().last().replaceWith(' ' + translations['answers'][id]['text'][id2]);
-							$(this).parent().contents().last().html(' ' + translations['answers'][id]['text'][id2]);
+						$('#'+id+'-tr .choicevert').each(function(){
+							$(this).show();
+							if($(this).find('[name="__chk__' + id + '_RC_' + id2 + '"]').length) {
+								$(this).contents().last().html(' ' + translations['answers'][id]['text'][id2]);
+								$(this).data('lang', lang);
+							} else if($(this).data('lang') !== lang) {
+								$(this).hide();
+							}
 						});
 					}
 					//enhanced checkboxes
 					for(id2 in translations['answers'][id]['text']){
 						$('.ec').each(function(){
 							var tmp = $(this).parent().attr('comps').split(',');
-							if(tmp[0] == id && tmp[2] == id2){
+							$(this).show();
+							if(tmp[0] == id && tmp[2] == id2) {
 								$(this).html(translations['answers'][id]['text'][id2]);
+								$(this).data('lang', lang);
+							} else if($(this).data('lang') !== lang) {
+								$(this).hide();
 							}
 						});
 					}

--- a/js/multilingual_survey.js
+++ b/js/multilingual_survey.js
@@ -556,7 +556,7 @@
 							if($(this).val() == id2){
 								$(this).text(translations['answers'][id]['text'][id2]);
 								$(this).data('lang', lang);
-							} else if($(this).val() !== '' && $(this).data('lang') !== lang) {
+							} else if(settings['hide-answers-without-translation-survey']['value'] && $(this).val() !== '' && $(this).data('lang') !== lang) {
 								$(this).hide();
 							}
 						});
@@ -597,7 +597,7 @@
 							if($(this).val() == id2){
 								$(this).parent().contents().last().html(' ' + translations['answers'][id]['text'][id2]);
 								$(this).data('lang', lang);
-							} else if($(this).data('lang') !== lang) {
+							} else if(settings['hide-answers-without-translation-survey']['value'] && $(this).data('lang') !== lang) {
 								$(this).parent().contents().last().hide();
 								$(this).hide();
 							}
@@ -611,7 +611,7 @@
 							if(tmp[0] == id && tmp[2] == id2) {
 								$(this).html(' ' + translations['answers'][id]['text'][id2]);
 								$(this).data('lang', lang);
-							} else if($(this).data('lang') !== lang) {
+							} else if(settings['hide-answers-without-translation-survey']['value'] && $(this).data('lang') !== lang) {
 								$(this).hide();
 							}
 						});
@@ -625,7 +625,7 @@
 							if($(this).find('[name="__chk__' + id + '_RC_' + id2 + '"]').length) {
 								$(this).contents().last().html(' ' + translations['answers'][id]['text'][id2]);
 								$(this).data('lang', lang);
-							} else if($(this).data('lang') !== lang) {
+							} else if(settings['hide-answers-without-translation-survey']['value'] && $(this).data('lang') !== lang) {
 								$(this).hide();
 							}
 						});
@@ -638,7 +638,7 @@
 							if(tmp[0] == id && tmp[2] == id2) {
 								$(this).html(translations['answers'][id]['text'][id2]);
 								$(this).data('lang', lang);
-							} else if($(this).data('lang') !== lang) {
+							} else if(settings['hide-answers-without-translation-survey']['value'] && $(this).data('lang') !== lang) {
 								$(this).hide();
 							}
 						});

--- a/js/multilingual_survey.js
+++ b/js/multilingual_survey.js
@@ -17,6 +17,7 @@
 	var translations = {};
 	var errorChecking = 0;
 	var anyTranslated = false;
+	var matrixProcessed = {};
 
 	//document ready change language
 	$( document ).ready(function(){
@@ -530,18 +531,28 @@
 			var id;
 			for(id in translations['questions']){
 				if(translations['questions'][id]['matrix'] != null){
+					if(!(translations['questions'][id]['matrix'] in matrixProcessed) && settings['hide-matrix-questions-without-translation-survey']['value']) {
+						$('tr[mtxgrp="'+translations['questions'][id]['matrix']+'"].mtxfld').each(function(){
+							var curMtxQuestionId = $(this).attr('id');
+							curMtxQuestionId = curMtxQuestionId.replace('-tr', '');
+							if(typeof translations['questions'][curMtxQuestionId] == 'undefined') {
+								$(this).hide();
+							} else {
+								$(this).show();
+							}
+						});
+						matrixProcessed[translations['questions'][id]['matrix']] = true;
+					}
 					//$('#' + id + '-tr').children('td').eq(1).children('table').children().children().children('td:first').html(translations['questions'][id]['text']);
 					$('#label-' + id).html(translations['questions'][id]['text']);
-				}
-				else if(translations['questions'][id]['type'] == 'descriptive'){
+				} else if(translations['questions'][id]['type'] == 'descriptive'){
 					var tmp = $('#' + id + '-tr').children('td').eq(1).html();
 					if(tmp != undefined){
 						$('#' + id + '-tr').children('td').eq(1).html(translations['questions'][id]['text']);
 						//tmp = tmp.split(/<(.+)/);
 						//$('#' + id + '-tr').children('td').eq(1).html(translations['questions'][id]['text'] + ' <' + tmp[1]);
 					}
-				}
-				else{
+				} else {
 					$('#label-' + id).html(translations['questions'][id]['text']);
 				}
 			}
@@ -585,6 +596,7 @@
 						//translations['answers'][id]['text'][id2]);
 						//$('#' + translations['answers'][id]['matrix'] + '-mtxhdr-tr').children('td').eq(1).children().children().children().children('td').eq(counter).html(translations['answers'][id]['text'][id2]);
 						$('#matrixheader-' + translations['answers'][id]['matrix'] + '-' + id2).html(translations['answers'][id]['text'][id2]);
+						// $('#matrixheader-' + translations['answers'][id]['matrix'] + '-' + id2).html('Answer');
 						counter++;
 					}
 				}
@@ -808,6 +820,7 @@
 					translations = r;
 					langReady = 1;
 					anyTranslated = true;
+					matrixProcessed = {};
 				}
 			},
 			error: function(jqXHR, textStatus, errorThrown) {


### PR DESCRIPTION
I have added some options to the settings to hide radio/checkbox/dropdown answers that are not provided with a translation for the currently selected language. 

I have also added an option to hide field matrix questions without a translation.