### PR TITLE
Remove chmod call on multilingualPDF.php

### DIFF
--- a/multilingualPDF.php
+++ b/multilingualPDF.php
@@ -90,7 +90,6 @@
 	
 	//save metadata to file
 	file_put_contents(APP_PATH_DOCROOT."PDF".DS."$random.json", json_encode($metadata));
-	chmod(775, APP_PATH_DOCROOT."PDF".DS."$random.php");
 	
 	//split up PDF/index.php file and add details
 	$pdfFile = file_get_contents(APP_PATH_DOCROOT."PDF".DS."index.php");


### PR DESCRIPTION
Didn't seem to be needed as PHP/$random.php is never actually referenced again, just PHP/index_multilingual_$random.php
Also, PHP/$random.php has a very remote chance of being PHP/functions.php, which is an actual REDCap file.