### PR TITLE
fix issue where translate() was deleting survey answer input elements

### DIFF
--- a/js/multilingual_survey.js
+++ b/js/multilingual_survey.js
@@ -537,6 +537,14 @@ var Multilingual = (function(){
 			//remove required english label
 			$('.requiredlabel').remove();
 			$('.multilingual').remove();
+			
+			// local function for handling radio question translation on mobile viewports
+			var translateMobileQuestion = function(label, replacement) {
+				label.find('div:first-child p').remove()
+				var remains = label.children('div:first-child').contents()
+				label.html(replacement)
+				label.children('div:first-child').append(remains)
+			}
 
 			//questions
 			var id;
@@ -564,7 +572,13 @@ var Multilingual = (function(){
 						//$('#' + id + '-tr').children('td').eq(1).html(translations['questions'][id]['text'] + ' <' + tmp[1]);
 					}
 				} else {
-					$('#label-' + id).html(translations['questions'][id]['text']);
+					if ($('#label-' + id).has('input').length > 0) {
+						// translate assuming it's mobile style where input is nested in label element
+						translateMobileQuestion($('#label-' + id), translations['questions'][id]['text']);
+					} else {
+						// translate as normal
+						$('#label-' + id).html(translations['questions'][id]['text']);
+					}
 				}
 			}
 


### PR DESCRIPTION
We were having an issue where the module's translate function was removing survey answer input elements via some of the .html(...) jquery calls. I added a function that detects whether a question label has nested inputs. If so, it will extract and re-insert them after the label is translated.