### PR TITLE
Add Multilingual module settings to Survey Settings Page

### DIFF
--- a/Multilingual.php
+++ b/Multilingual.php
@@ -11,7 +11,13 @@ class Multilingual extends AbstractExternalModule
 	function redcap_survey_page($project_id, $record, $instrument, $event_id, $group_id, $survey_hash, $response_id, $repeat_instance){
 		$api_endpoint = $this->getProjectSetting('use-api-endpoint', $project_id);
 		// Update and add multilingual_survey.js
-		echo '<script type="text/javascript">' . str_replace('REDCAP_PDF_URL', ($this->getProjectSetting('multilingual-econsent', $project_id) ? $this->getUrl("multilingualPDF.php", true, ($api_endpoint == true ? true : false)) : 'false') . '&id=' . $record . '&form=' . $instrument . '&event_id=' . $event_id . '&instance=' . $repeat_instance, str_replace('APP_PATH_IMAGES', APP_PATH_IMAGES, str_replace('REDCAP_LANGUAGE_VARIABLE', $this->languageVariable($project_id), str_replace('REDCAP_AJAX_URL', $this->getUrl("index.php", true, ($api_endpoint == true ? true : false)), file_get_contents($this->getModulePath() . 'js/multilingual_survey.js'))))) . '</script>';
+		echo '<script type="text/javascript">' . 
+		str_replace('REDCAP_PDF_URL', ($this->getProjectSetting('multilingual-econsent', $project_id) ? $this->getUrl("multilingualPDF.php", true, ($api_endpoint == true ? true : false)) : 'false') . '&id=' . $record . '&form=' . $instrument . '&event_id=' . $event_id . '&instance=' . $repeat_instance, 
+		str_replace('APP_PATH_IMAGES', APP_PATH_IMAGES, 
+		str_replace('REDCAP_INSTRUMENT_NAME', $instrument, 
+		str_replace('REDCAP_LANGUAGE_VARIABLE', $this->languageVariable($project_id), 
+		str_replace('REDCAP_AJAX_URL', $this->getUrl("index.php", true, ($api_endpoint == true ? true : false)), 
+		file_get_contents($this->getModulePath() . 'js/multilingual_survey.js')))))) . '</script>';
 		echo '<link rel="stylesheet" type="text/css" href="' .  $this->getUrl('css/multilingual.css', true, $api_endpoint == true) . '">';
 	}
 
@@ -28,6 +34,7 @@ class Multilingual extends AbstractExternalModule
 
 	function redcap_every_page_top($project_id){
 		$api_endpoint = $this->getProjectSetting('use-api-endpoint', $project_id);
+		$at_survey_settings = strpos($_SERVER['REQUEST_URI'], 'Surveys/edit_info.php') !== false || strpos($_SERVER['REQUEST_URI'], 'Surveys/create_survey.php') !== false;
 		
 		//$user_rights = REDCap::getUserRights();
 		//echo json_encode($user_rights);
@@ -39,13 +46,32 @@ class Multilingual extends AbstractExternalModule
 		elseif(strpos($_SERVER['REQUEST_URI'], 'DataExport/index.php') !== false){
 			echo '<script type="text/javascript">' . str_replace('REDCAP_LANGUAGE_VARIABLE', $this->languageVariable($project_id), str_replace('REDCAP_AJAX_URL', $this->getUrl("index.php", true), file_get_contents($this->getModulePath() . 'js/multilingual_export.js'))) . '</script>';
 		}
-		elseif($_GET['__return'] == 1){
-			echo '<script type="text/javascript">' . str_replace('APP_PATH_IMAGES', APP_PATH_IMAGES, str_replace('REDCAP_LANGUAGE_VARIABLE', $this->languageVariable($project_id), str_replace('REDCAP_AJAX_URL', $this->getUrl("index.php", true, ($api_endpoint == true ? true : false)), file_get_contents($this->getModulePath() . 'js/multilingual_survey_return.js')))) . '</script>';
+		elseif($_GET['__return'] == 1 or (isset($_GET['s']) && !isset($_GET['__page__']))){
+			// $instrument = $this->getInstrumentNameFromSurveyHash($project_id);
+			$instrument = $_GET['page'];
+			echo '<script type="text/javascript">' . 
+			str_replace('APP_PATH_IMAGES', APP_PATH_IMAGES, 
+			str_replace('REDCAP_LANGUAGE_VARIABLE', $this->languageVariable($project_id), 
+			str_replace('REDCAP_INSTRUMENT_NAME', $instrument, 
+			str_replace('REDCAP_AJAX_URL', $this->getUrl("index.php", true, ($api_endpoint == true ? true : false)), 
+			file_get_contents($this->getModulePath() . 'js/multilingual_survey_return.js'))))) . '</script>';
+			
 			echo '<link rel="stylesheet" type="text/css" href="' .  $this->getUrl('css/multilingual.css', true, ($api_endpoint == true ? true : false)) . '">';
 		}
 		elseif(strpos($_SERVER['REQUEST_URI'], 'DataEntry/index.php') !== false || strpos($_SERVER['REQUEST_URI'], 'DataEntry/record_home.php') !== false){
 			echo '<link rel="stylesheet" type="text/css" href="' .  $this->getUrl('css/multilingual.css') . '">';
 			echo '<script type="text/javascript">' . str_replace('PDF_URL', $this->getUrl("multilingualPDF.php", true), str_replace('APP_PATH_IMAGES', APP_PATH_IMAGES, str_replace('REDCAP_LANGUAGE_VARIABLE', $this->languageVariable($project_id), str_replace('REDCAP_AJAX_URL', $this->getUrl("index.php", true), file_get_contents($this->getModulePath() . 'js/multilingual_pdf.js'))))) . '</script>';
+		}
+		elseif($at_survey_settings && isset($_GET['page'])){
+			$index_url = $this->getUrl("index.php", true, ($api_endpoint == true ? true : false));
+			$language_var = $this->languageVariable($project_id);
+			$stylesheet = '<link rel="stylesheet" type="text/css" href="' .  $this->getUrl('css/multilingual.css') . '">';
+			$ml_survey_settings_js = '<script type="text/javascript">' . file_get_contents($this->getUrl('js/multilingual_survey_settings.js')) . '</script>';
+			$ml_survey_settings_js = str_replace('REDCAP_AJAX_URL', $index_url, $ml_survey_settings_js);
+			$ml_survey_settings_js = str_replace('REDCAP_LANGUAGE_VARIABLE', $language_var, $ml_survey_settings_js);
+			
+			echo $stylesheet;
+			echo $ml_survey_settings_js;
 		}
 	}
 
@@ -78,6 +104,48 @@ class Multilingual extends AbstractExternalModule
 			$langVar = 'languages';
 		}
 		return $langVar;
+	}
+	
+	public function getSurveySettings($data) {
+		$instruments = $this->getProjectSetting('instruments');
+		
+		if (!empty($instruments)) {
+			$instruments = json_decode($instruments);
+			$name = htmlspecialchars($data['instrument']);
+			$instrument = $instruments->$name;
+		} else {
+			$instruments = new \stdClass();
+		}
+		
+		header('Content-Type: application/json');
+		echo json_encode($instrument);
+	}
+	
+	public function saveSurveySettings($data) {
+		$instruments = $this->getProjectSetting('instruments');
+		$instrument = htmlspecialchars($data['instrument']);
+		$lang = htmlspecialchars($data['language']);
+		if (empty($instruments)) {
+			$instruments = new \stdClass();
+		} else {
+			$instruments = json_decode($instruments);
+		}
+		if (empty($instruments->$instrument)) {
+			$instruments->$instrument = new \stdClass();
+		}
+		if (empty($instruments->$instrument->$lang)) {
+			$instruments->$instrument->$lang = new \stdClass();
+		}
+		foreach ($data['collections'] as $coll_name => $coll) {
+			$instruments->$instrument->$lang->$coll_name = new \stdClass();
+			
+			// add each setting to collection after encoding HTML
+			foreach ($coll as $sname => $setting) {
+				$instruments->$instrument->$lang->$coll_name->$sname = htmlspecialchars($setting);
+			}
+		}
+		
+		$this->setProjectSetting('instruments', json_encode($instruments));
 	}
 
 	public function getSettings($data){
@@ -344,6 +412,26 @@ class Multilingual extends AbstractExternalModule
 							}
 						}
 					}
+				}
+			}
+		}
+		
+		// override
+		$instruments = $this->getProjectSetting('instruments');
+		if (!empty($instruments)) {
+			$instruments = json_decode($instruments);
+			$form_name = $data['page'];
+			$this_lang = $data['lang'];
+			$simple_settings = $instruments->$form_name->$this_lang;
+			if (!empty($simple_settings)) {
+				$general_settings = $simple_settings->survey_settings;
+				if (!empty($general_settings)) {
+					if (!empty($general_settings->title) || $general_settings->title == "")
+						$response['surveytext']['surveytitle'] = html_entity_decode($general_settings->title);
+					if (!empty($general_settings->instructions) || $general_settings->instructions == "")
+						$response['surveytext']['surveyinstructions'] = html_entity_decode($general_settings->instructions);
+					if (!empty($general_settings->acknowledgement) || $general_settings->acknowledgement == "")
+						$response['surveytext']['surveyacknowledgment'] = html_entity_decode($general_settings->acknowledgement);
 				}
 			}
 		}

--- a/css/multilingual.css
+++ b/css/multilingual.css
@@ -67,3 +67,12 @@
 	cursor:pointer;
 	box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.3), 0 6px 20px 0 rgba(0, 0, 0, 0.30);
 }
+
+label.ml-mod {
+	display: inline;
+	margin: 0px 4px 0px 124px;
+}
+
+select#ml-mod-language {
+	min-width: 80px;
+}

--- a/index.php
+++ b/index.php
@@ -8,6 +8,12 @@
 
 	if(isset($data) && $data != ''){
 		$data = json_decode($data, true);
+		
+		if ($data['action'] == 'SAVE_SURVEY_SETTINGS') {
+			$module->saveSurveySettings($data);
+		} else if ($data['action'] == 'GET_SURVEY_SETTINGS') {
+			$module->getSurveySettings($data);
+		}
 
 		switch($data['todo']){
 			case 1:

--- a/js/multilingual_survey.js
+++ b/js/multilingual_survey.js
@@ -537,6 +537,14 @@ var Multilingual = (function(){
 			//remove required english label
 			$('.requiredlabel').remove();
 			$('.multilingual').remove();
+			
+			// local function for handling radio question translation on mobile viewports
+			var translateMobileQuestion = function(label, replacement) {
+				label.find('div:first-child p').remove()
+				var remains = label.children('div:first-child').contents()
+				label.html(replacement)
+				label.children('div:first-child').append(remains)
+			}
 
 			//questions
 			var id;
@@ -564,7 +572,13 @@ var Multilingual = (function(){
 						//$('#' + id + '-tr').children('td').eq(1).html(translations['questions'][id]['text'] + ' <' + tmp[1]);
 					}
 				} else {
-					$('#label-' + id).html(translations['questions'][id]['text']);
+					if ($('#label-' + id).has('input').length > 0) {
+						// translate assuming it's mobile style where input is nested in label element
+						translateMobileQuestion($('#label-' + id), translations['questions'][id]['text']);
+					} else {
+						// translate as normal
+						$('#label-' + id).html(translations['questions'][id]['text']);
+					}
 				}
 			}
 

--- a/js/multilingual_survey_settings.js
+++ b/js/multilingual_survey_settings.js
@@ -1,0 +1,384 @@
+var Multilingual = {}
+Multilingual.ajax_url = 'REDCAP_AJAX_URL';
+Multilingual.langVar = 'REDCAP_LANGUAGE_VARIABLE';
+Multilingual.languages = {1: 'en', 2: 'es'};
+
+Multilingual.getSettings = function() {
+	var data = {};
+	data['todo'] = 3;
+	data['project_id'] = pid;
+	var json = encodeURIComponent(JSON.stringify(data));
+
+	$.ajax({
+		url: Multilingual.ajax_url,
+		type: 'POST',
+		data: 'data=' + json,
+		success: function (r) {
+			settings = r;
+		},
+		error: function(jqXHR, textStatus, errorThrown) {
+		   console.log(textStatus, errorThrown);
+		}
+	});
+}
+
+Multilingual.getLanguages = function() {
+	var data = {};
+	data['todo'] = 2;
+	data['project_id'] = Multilingual.getVariable('pid');
+	data['field_name'] = Multilingual.langVar;
+	var json = encodeURIComponent(JSON.stringify(data));
+	
+	$.ajax({
+		url: Multilingual.ajax_url,
+		type: 'POST',
+		data: 'data=' + json,
+		success: function (r) {
+			Multilingual.languages = r;
+			Multilingual.addSurveySettingsLanguageRow(Multilingual.languages);
+		},
+		error: function(jqXHR, textStatus, errorThrown) {
+			console.log(textStatus, errorThrown);
+		}
+	});
+}
+
+Multilingual.getVariable = function(variable) {
+	var query = window.location.search.substring(1);
+	var vars = query.split("&");
+	for (var i=0;i<vars.length;i++) {
+		   var pair = vars[i].split("=");
+		   if(pair[0] == variable){return pair[1];}
+	}
+	return(false);
+}
+
+Multilingual.htmlDecode = function(input) {
+	// from https://stackoverflow.com/questions/1248849/converting-sanitised-html-back-to-displayable-html
+	var e = document.createElement('div');
+	e.innerHTML = input;
+	return e.childNodes[0].nodeValue;
+}
+
+//
+Multilingual.onLanguageSelect = function() {
+	var selectVal = $("select#ml-mod-language").val();
+	if (selectVal == "") {
+		this.disableTextSettings();
+		this.selectedLanguage = null;
+		this.loadSurveySettings();
+	} else {
+		this.enableTextSettings();
+		var lang_index = Number($("select#ml-mod-language").val()) + 1;
+		this.selectedLanguage = this.languages[lang_index];
+		this.loadSurveySettings();
+	}
+}
+	
+Multilingual.addSurveySettingsLanguageRow = function(languages) {
+	// make language select element
+	var langSelect = "<select id='ml-mod-language' name='ml-mod-language' class='x-form-text x-form-field' onchange='Multilingual.onLanguageSelect();'>"
+	langSelect += "<option value=''></option>"
+	Object.values(languages).forEach(function(value, index) {
+		langSelect += "<option value='" + parseInt(index) + "'>" + value + "</option>"
+	});
+	langSelect += "</select>";
+	
+	var langLabel = "<label class='ml-mod' for='ml-mod-language'>Translation Language</label>"
+	
+	var emIcon = "<i class='fas fa-cube fs14' style='position:relative;top:1px;margin-right:1px;margin-left:1px;'></i>";
+	
+	var ssRow = "<tr><td colspan=3><div class='header' style='padding:7px 10px 5px;margin:-5px -7px 0px; background-color: #fb8;>'";
+	ssRow += "<span>" + emIcon + " Multilingual Module - Select a translation language to change text settings</span>" + langLabel + langSelect
+	ssRow += "</div></td></tr>";
+	
+	$("#survey_settings tbody tr:first").after(ssRow);
+}
+
+Multilingual.addSaveAndReturnSection = function() {
+	// add a section for Save and Return text translation settings in the Survey Settings page form table
+	
+	// add section header tr
+	var emIcon = "<i class='fas fa-cube fs14' style='position:relative;top:1px;margin-right:1px;margin-left:1px;'></i>";
+	var newRow = "<tr id='ml_save_and_return-tr'><td colspan=3><div class='header' style='padding:7px 10px 5px;margin:0 -7px 10px; background-color: #fb8;>'";
+	newRow += "<span>" + emIcon + " Multilingual Module - Save & Return Later Text Translations</span></div></td></tr>"
+	
+	// prepare section tr template
+	var blank_tr = $("<tr class='ml-snr-settings'>\
+		<td valign='top' style='width:20px;'></td>\
+		<td valign='top' style='width:290px;'></td>\
+		<td valign='top' style='padding-left:15px;padding-bottom:5px;'></td>\
+	</tr>")
+	
+	// Survery Page Texts <tr>
+	var surveypage_tr = blank_tr.clone()
+	$(surveypage_tr).find('td:nth-child(2)').append("<b>Survey Page Text</b>")
+	$(surveypage_tr).find('td:nth-child(3)').append("<span style='display:block;'>'Save & Return Later' button text. This button appears below the survey's 'Submit' button:</span>\
+	<div style='margin:1px 0px;'><input class='ml-text-setting' data-collection='save_and_return_survey' data-setting='button' value='Save & Return Later' style='width:60%'></div>\
+	<span style='display:block; margin:4px 0px;'>The texts below appear in the top right corner of the survey page. The pop-up prompts the user to continue the survey where they left off:</span>\
+	<div style='margin:2px 0px;'><input class='ml-text-setting' data-collection='save_and_return_survey' data-setting='popup_hint' value='Returning?' style='width:60%'></div>\
+	<div style='margin:2px 0px;'><input class='ml-text-setting'  data-collection='save_and_return_survey' data-setting='popup_title' value='Begin where you left off.' style='width:60%'></div>\
+	<textarea style='width:98%;height:60px;font-size:12px;' class='tinyNoEditor ml-text-setting' data-collection='save_and_return_survey' data-setting='popup_text'>If you have already completed part of the survey, you may continue where you left off. All you need is the return code given to you previously. Click the link below to begin entering your return code and continue the survey.</textarea>\
+	<div style='margin:2px 0px;'><input class='ml-text-setting' data-collection='save_and_return_survey' data-setting='popup_button' value='Continue the survey' style='width:60%'</div>")
+	
+	// Response Saved Page Texts <tr>
+	var saved_tr = blank_tr.clone()
+	$(saved_tr).find('td:nth-child(2)').append("<b>Survey Responses Saved Page Text</b>")
+	$(saved_tr).find('td:nth-child(3)').append("<span style='display:block;'>This page appears after a user decides to save their survey responses thus far and leave the survey.</span>\
+	<br>\
+	<div style='margin:2px 0px;'><input class='ml-text-setting' data-collection='save_and_return_saved' data-setting='title' value='Your survey responses were saved!' style='width:80%'> (page title)</div>\
+	<span style='display:block;'>These page instructions appear below the title:</span>\
+	<textarea style='width:98%;height:60px;font-size:12px;' class='tinyNoEditor ml-text-setting' data-collection='save_and_return_saved' data-setting='instructions1'>You have chosen to stop the survey for now and return at a later time to complete it. To return to this survey, you will need both the survey link and your return code. See the instructions below.</textarea>\
+	<br>\
+	<div style='margin:2px 0px;'><input data-collection='save_and_return_saved' data-setting='return_code' class='ml-text-setting' value='Return Code' style='width:60%'> (section heading)</div>\
+	<textarea data-collection='save_and_return_saved' data-setting='req_note' style='width:98%;height:40px;font-size:12px;' class='tinyNoEditor ml-text-setting'>A return code is *required* in order to continue the survey where you left off. Please write down the value listed below.</textarea>\
+	<div style='margin:2px 0px;'><input data-collection='save_and_return_saved' data-setting='footnote1' class='ml-text-setting' value='The return code will NOT be included in the email below.' style='width:80%'> (footnote)</div>\
+	<br>\
+	<div style='margin:2px 0px;'><input data-collection='save_and_return_saved' data-setting='heading1' class='ml-text-setting' value='Survey link for returning' style='width:60%'> (section heading)</div>\
+	<textarea data-collection='save_and_return_saved' data-setting='instructions2' style='width:98%;height:80px;font-size:12px;' class='tinyNoEditor ml-text-setting'>You may bookmark this page to return to the survey, OR you can have the survey link emailed to you by providing your email address below. For security purposes, the return code will NOT be included in the email. If you do not receive the email soon afterward, please check your Junk Email folder.</textarea>\
+	<div style='margin:2px 0px;'><input data-collection='save_and_return_saved' data-setting='email_input' class='ml-text-setting' value='Enter email address' style='width:60%'> (default input text)</div>\
+	<div style='margin:2px 0px;'><input data-collection='save_and_return_saved' data-setting='send_link' class='ml-text-setting' value='Send Survey Link' style='width:60%'> (button to send email)</div>\
+	<div style='margin:2px 0px;'><input data-collection='save_and_return_saved' data-setting='footnote2' class='ml-text-setting' value='Your email address will not be stored' style='width:80%'> (footnote)</div>\
+	<br>\
+	<div style='margin:2px 0px;'><input data-collection='save_and_return_saved' data-setting='instructions3' class='ml-text-setting' value='Or if you wish, you may continue with this survey again now.' style='width:80%'></div>\
+	<div style='margin:2px 0px;'><input data-collection='save_and_return_saved' data-setting='continue' class='ml-text-setting' value='Continue Survey Now' style='width:60%'> (button to continue survey)</div>\
+	")
+	
+	// Response saved page intro modal <tr>
+	var saved_intro_modal_tr = blank_tr.clone()
+	$(saved_intro_modal_tr).find('td:nth-child(2)').append("Responses Saved Page -- Instructions Modal")
+	$(saved_intro_modal_tr).find('td:nth-child(3)').append("<span style='display:block;'>A modal appears immediately after the user saves their responses instructing them to copy and remember their Return Code:</span>\
+	<div style='margin:2px 0px;'><input data-collection='save_and_return_modals' data-setting='intro_title' class='ml-text-setting' value='&apos;Return Code&apos; needed to return' style='width:80%'> (modal title)</div>\
+	<textarea data-collection='save_and_return_modals' data-setting='intro_body' style='width:98%;height:80px;font-size:12px;' class='tinyNoEditor ml-text-setting'>Copy or write down the Return Code below. Without it, you will not be able to return and continue this survey. Once you have the code, click Close and follow the other instructions on this page.</textarea>\
+	<div style='margin:2px 0px;'><input data-collection='save_and_return_modals' data-setting='close' class='ml-text-setting' value='Close' style='width:60%'> (button to close modal)</div>\
+	")
+	
+	// Returning to Survey Page Email Modal <tr>
+	var saved_email_modal_tr = blank_tr.clone()
+	$(saved_email_modal_tr).find('td:nth-child(2)').append("Responses Saved Page -- 'Email Sent' Modal")
+	$(saved_email_modal_tr).find('td:nth-child(3)').append("<span style='display:block;'>A modal appears after a user types their email addess and clicks the 'Send Survey Link' button. The modal has a title, message, adn close button whose texts you can specify below:</span>\
+	<div style='margin:2px 0px;'><input data-collection='save_and_return_modals' data-setting='email_title' class='ml-text-setting' value='Email sent!' style='width:60%'> (modal title)</div>\
+	<div style='margin:2px 0px;'><input data-collection='save_and_return_modals' data-setting='email_body' class='ml-text-setting' value='The email was successfully sent to ' style='width:60%'> ... sent to [user's email address]</div>\
+	")
+	
+	// Returning to Survey Page error Modal <tr>
+	var saved_error_modal_tr = blank_tr.clone()
+	$(saved_error_modal_tr).find('td:nth-child(2)').append("Responses Saved Page -- Invalid Email Modal")
+	$(saved_error_modal_tr).find('td:nth-child(3)').append("<span style='display:block;'>A modal appears if the user supplies an invalid email address:</span>\
+	<div style='margin:2px 0px;'><input data-collection='save_and_return_modals' data-setting='error_title' class='ml-text-setting' value='Alert' style='width:60%'> (modal title)</div>\
+	<textarea data-collection='save_and_return_modals' data-setting='error_body' style='width:98%;height:40px;font-size:12px;' class='tinyNoEditor ml-text-setting'>This field must be a valid email address (like joe@user.com). Please re-enter it now.</textarea>\
+	")
+	
+	// Returning to Survey Page Texts <tr>
+	var return_tr = blank_tr.clone()
+	$(return_tr).find('td:nth-child(2)').append("<b>Return to Survey Page</b>")
+	$(return_tr).find('td:nth-child(3)').append("<span style='display:block;'>When a user clicks the link in their email to return to the survey, they'll first see a landing page which requests that they enter their Return Code. Below are the instructions shown to the user:</span>\
+	<textarea data-collection='save_and_return_returned' data-setting='instructions' style='width:98%;height:60px;font-size:12px;' class='tinyNoEditor ml-text-setting'>To continue the survey, please enter the RETURN CODE that was auto-generated for you when you left the survey. Please note that the return code is *not* case sensitive.</textarea>\
+	<div style='margin:2px 0px;'><input data-collection='save_and_return_returned' data-setting='submit_code' class='ml-text-setting' value='Submit your Return Code' style='width:60%'> (button to submit return code)</div>\
+	<span style='display:block;'>If the user supplies an invalid return code, the following error message is shown to them:</span>\
+	<textarea data-collection='save_and_return_returned' data-setting='error' style='width:98%;height:60px;font-size:12px;' class='tinyNoEditor ml-text-setting'>The return code you entered was incorrect. Please try again.</textarea>\
+	<span style='display:block;'>The return page also gives the user an option to erase their responses for this survey and start over:</span>\
+	<textarea data-collection='save_and_return_returned' data-setting='start_over_instructions' style='width:98%;height:80px;font-size:12px;' class='tinyNoEditor ml-text-setting'>Alternatively, if you have forgotten your return code or simply wish to start the survey over from the beginning, you may delete all your existing survey responses and start over.</textarea>\
+	<div style='margin:2px 0px;'><input data-collection='save_and_return_returned' data-setting='start_over_button' class='ml-text-setting' value='Start Over' style='width:60%'> (button to start over)</div>\
+	<span style='display:block;'>When a user clicks the 'Start Over' button, a prompt appears with the following text:</span>\
+	<textarea data-collection='save_and_return_returned' data-setting='start_over_prompt' style='width:98%;height:60px;font-size:12px;' class='tinyNoEditor ml-text-setting'>ERASE YOUR RESPONSES? Are you sure you wish to start the survey over from the beginning? Please note that doing so will erase ALL your responses already entered for this survey.</textarea>\
+	")
+	
+	// insert these table rows into DOM
+	$("#save_and_return-tr").next("tr").before(newRow, surveypage_tr, saved_tr, saved_intro_modal_tr, saved_email_modal_tr, saved_error_modal_tr, return_tr);
+}
+
+Multilingual.disableTextSettings = function() {
+	$("input[name='title']").attr('disabled', true)
+	$("input[name='title']").css('background-color', "#ccc")
+	$("textarea[name='response_limit_custom_text']").attr('disabled', true)
+	tinyMCE.editors["instructions"].getBody().setAttribute('contenteditable', false)
+	tinyMCE.editors["instructions"].getBody().style.backgroundColor = "#ccc"
+	tinyMCE.editors["acknowledgement"].getBody().setAttribute('contenteditable', false)
+	tinyMCE.editors["acknowledgement"].getBody().style.backgroundColor = "#ccc"
+	
+	// disable save and return later added settings
+	$("textarea.ml-text-setting, input.ml-text-setting").attr('disabled', true)
+}
+
+Multilingual.enableTextSettings = function() {
+	$("input[name='title']").attr('disabled', false)
+	$("input[name='title']").css('background-color', "#fff")
+	$("textarea[name='response_limit_custom_text']").attr('disabled', false)
+	tinyMCE.editors["instructions"].getBody().setAttribute('contenteditable', true);
+	tinyMCE.editors["instructions"].getBody().style.backgroundColor = "#fff"
+	tinyMCE.editors["acknowledgement"].getBody().setAttribute('contenteditable', true);
+	tinyMCE.editors["acknowledgement"].getBody().style.backgroundColor = "#fff"
+	
+	// disable save and return later added settings
+	$("textarea.ml-text-setting, input.ml-text-setting").attr('disabled', null)
+}
+
+Multilingual.saveSurveySettings = function() {
+	if (!this.selectedLanguage)		// only save module settings if translation language selected
+		return false;
+	
+	var data = {}
+	data.action = 'SAVE_SURVEY_SETTINGS'
+	data.instrument = Multilingual.getVariable('page')
+	data.language = this.selectedLanguage
+	data.collections = {}
+	
+	// build survey_settings collection of settings
+	var survey_settings = {}
+	survey_settings.title = $("input[name=title]").val()
+	survey_settings.instructions = tinymce.editors.instructions.getContent()
+	survey_settings.response_limit = $("textarea[name=response_limit_custom_text]").val()
+	survey_settings.acknowledgement = tinymce.editors.acknowledgement.getContent()
+	data.collections.survey_settings = survey_settings
+	
+	// add 'Save and Return Later' setting collections
+	let coll_names = [
+		"save_and_return_survey",
+		"save_and_return_saved",
+		"save_and_return_modals",
+		"save_and_return_error",
+		"save_and_return_returned"
+	]
+	coll_names.forEach(function(coll_name, i) {
+		data.collections[coll_name] = {}
+		$(".ml-text-setting[data-collection='" + coll_name + "']").each(function(i, setting) {
+			data.collections[coll_name][$(setting).attr('data-setting')] = $(setting).val()
+		})
+	})
+	
+	var json = encodeURIComponent(JSON.stringify(data));
+	
+	$.ajax({
+		url: Multilingual.ajax_url,
+		type: 'POST',
+		data: 'data=' + json,
+		error: function(jqXHR, textStatus, errorThrown) {
+			console.log(textStatus, errorThrown);
+		}
+	});
+	
+	// load default survey settings so REDCap doesn't overwrite them
+	this.selectedLanguage = null;
+	this.loadSurveySettings();
+}
+
+Multilingual.getSurveySettings = function() {
+	// remember default survey settings
+	Multilingual.defaults = {}
+	Multilingual.defaults.survey_settings = {}
+	Multilingual.defaults.survey_settings.title = $("input[name=title]").val();
+	Multilingual.defaults.survey_settings.instructions = tinymce.editors.instructions.getContent();
+	Multilingual.defaults.survey_settings.response_limit = $("textarea[name=response_limit_custom_text]").val();
+	Multilingual.defaults.survey_settings.acknowledgement = tinymce.editors.acknowledgement.getContent();
+	
+	// store default 'Save and Return Later' settings as well
+	let coll_names = [
+		"save_and_return_survey",
+		"save_and_return_saved",
+		"save_and_return_modals",
+		"save_and_return_error",
+		"save_and_return_returned"
+	]
+	coll_names.forEach(function(coll_name, i) {
+		Multilingual.defaults[coll_name] = {}
+		$(".ml-text-setting[data-collection='" + coll_name + "']").each(function(i, setting) {
+			Multilingual.defaults[coll_name][$(setting).attr('data-setting')] = $(setting).val()
+		})
+	})
+	
+	var data = {
+		action: 'GET_SURVEY_SETTINGS'
+	}
+	data.instrument = Multilingual.getVariable('page');
+	var json = encodeURIComponent(JSON.stringify(data));
+	
+	$.ajax({
+		url: Multilingual.ajax_url,
+		type: 'POST',
+		data: 'data=' + json,
+		success: function(r) {
+			if (r) {
+				Multilingual.settings = r;
+				for (let [lang, collections] of Object.entries(Multilingual.settings)) {
+					// console.log('lang, collections', [lang, collections])
+					for (let [coll_name, collection] of Object.entries(collections)) {
+						// console.log('coll_name, collection', [coll_name, collection])
+						for (let [setting, value] of Object.entries(collection)) {
+							if (value)
+								Multilingual.settings[lang][coll_name][setting] = Multilingual.htmlDecode(value)
+							// console.log('setting, value', [setting, Multilingual.settings[lang][coll_name][setting]])
+						}
+					}
+				}
+			}
+		},
+		error: function(jqXHR, textStatus, errorThrown) {
+			console.log(textStatus, errorThrown);
+		}
+	});
+}
+
+Multilingual.loadSurveySettings = function() {
+	var collections = this.defaults
+	if (this.selectedLanguage && typeof(this.settings) !== 'undefined') {
+		if (typeof(this.settings[this.selectedLanguage]) !== 'undefined') {
+			collections = this.settings[this.selectedLanguage];
+		}
+	}
+	
+	// handles setting input values for settings that exist in every REDCap survey
+	$("input[name='title']").val(collections.survey_settings.title)
+	tinyMCE.editors.instructions.setContent(collections.survey_settings.instructions);
+	$("textarea[name='response_limit_custom_text']").val(collections.survey_settings.response_limit)
+	tinyMCE.editors.acknowledgement.setContent(collections.survey_settings.acknowledgement);
+	
+	// handles all settings that are added by ML module itself
+	$(".ml-text-setting[data-collection][data-setting]").each(function(i, setting) {
+		var coll_name = $(this).attr('data-collection')
+		var setting_name = $(this).attr('data-setting')
+		// console.log('hit element with coll name, setting_name: ', coll_name + " " + setting_name)
+		
+		if (collections[coll_name]) {
+			$(this).val(collections[coll_name][setting_name] || this.defaults[coll_name][setting_name])
+		}
+	})
+}
+
+Multilingual.getSettings();
+
+$( document ).ready(function() {
+	Multilingual.getLanguages();
+	
+	// disable text settings when both tinyMCE editors are init'ed
+	tinyMCE.editors["instructions"].on('init', function(e) {
+		Multilingual.instructionsEditorReady = true;
+		if (Multilingual.acknowledgementEditorReady && Multilingual.instructionsEditorReady) {
+			Multilingual.disableTextSettings();
+			Multilingual.getSurveySettings();
+		}
+	})
+	tinyMCE.editors["acknowledgement"].on('init', function(e) {
+		Multilingual.acknowledgementEditorReady = true;
+		if (Multilingual.acknowledgementEditorReady && Multilingual.instructionsEditorReady) {
+			Multilingual.disableTextSettings();
+			Multilingual.getSurveySettings();
+		}
+	})
+
+	$("#surveySettingsSubmit").on('click', function() {
+		Multilingual.saveSurveySettings();
+	});
+	
+	Multilingual.addSaveAndReturnSection();
+	$("select[name='save_and_return']").on('change', function() {
+		if ($(this).val() == '1') {
+			$("#ml_save_and_return-tr").show()
+			$("tr.ml-snr-settings").show()
+		} else {
+			$("#ml_save_and_return-tr").hide()
+			$("tr.ml-snr-settings").hide()
+		}
+	})
+	$("select[name='save_and_return']").trigger('change')
+})


### PR DESCRIPTION
REDCap survey administrators can configure text translations via an
instrument's Survey Settings page in REDCap. Until a user selects a
translation language via the added drop-down select, text inputs are
disabled. Upon selecting a language, they are re-enabled. Text settings
are saved in the external module project setting called "instruments".
They are saved in JSON format according to instrument name and selected
translation language.

These new instrument-specific settings are backwards compatible with
the project-wide settings still available via the external module's
configuration modal.

Additionally, some missing text translations (e.g., some modals for the
Save and Return Later feature) are provided.

Quick preview of what some of the added settings look like to end users:
![image](https://user-images.githubusercontent.com/11524545/84697841-7546c380-af14-11ea-989a-42c32cd79cb0.png)
